### PR TITLE
Adding rewriting from HTML to DOM attributes

### DIFF
--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -7,8 +7,8 @@
 
 #+cljs
 (defn attributes [attrs]
-  (let [attrs (clj->js attrs)
-        class (join " " (flatten (seq (.-className attrs))))]
+  (let [class (join " " (flatten (seq (:class attrs))))
+        attrs (clj->js (dissoc attrs :class))]
     (if-not (blank? class)
       (set! (.-className attrs) class))
     attrs))

--- a/src/sablono/util.cljx
+++ b/src/sablono/util.cljx
@@ -28,17 +28,17 @@
    m (keys m)))
 
 (defn merge-with-class
-  "Like clojure.core/merge but concat :className entries."
+  "Like clojure.core/merge but concat :class entries."
   [& maps]
   (let [classes (->> (mapcat #(cond
                                (list? %1) [%1]
                                (vector? %1) %1
                                :else [%1])
-                             (map :className maps))
+                             (map :class maps))
                      (remove nil?) vec)
         maps (apply merge maps)]
     (if (empty? classes)
-      maps (assoc maps :className classes))))
+      maps (assoc maps :class classes))))
 
 (defn normalize-element
   "Ensure an element vector is of the form [tag-name attrs content]."
@@ -46,7 +46,7 @@
   (when (not (or (keyword? tag) (symbol? tag) (string? tag)))
     (throw (ex-info (str tag " is not a valid element name.") {:tag tag :content content})))
   (let [[_ tag id class] (re-matches re-tag (name tag))
-        tag-attrs {:id id :className (if class (split class #"\."))}
+        tag-attrs {:id id :class (if class (split class #"\."))}
         map-attrs (first content)]
     (if (map? map-attrs)
       [tag (compact-map (merge-with-class tag-attrs map-attrs)) (next content)]

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -77,7 +77,7 @@
      '[:div.foo (str "bar" "baz")]
      '(let* [attrs (str "bar" "baz")]
             (if (clojure.core/map? attrs)
-              (js/React.DOM.div (sablono.interpreter/attributes (sablono.util/merge-with-class {:className ["foo"]} attrs)) nil)
+              (js/React.DOM.div (sablono.interpreter/attributes (sablono.util/merge-with-class {:class ["foo"]} attrs)) nil)
               (js/React.DOM.div #js {:className "foo"} (sablono.interpreter/interpret attrs))))
      '[:div.a.b] '(js/React.DOM.div #js {:className "a b"})
      '[:div.a.b.c] '(js/React.DOM.div #js {:className "a b c"})
@@ -138,6 +138,11 @@
   (testing "attribute values are escaped"
     (are-html-expanded
      '[:div {:id "\""}] '(js/React.DOM.div #js {:id "\""})))
+  (testing "attributes are converted to their DOM equivalents"
+    (are-html-expanded
+     '[:div {:class "classy"}] '(js/React.DOM.div #js {:className "classy"})
+     '[:div {:data-foo-bar "baz"}] '(js/React.DOM.div #js {:dataFooBar "baz"})
+     '[:label {:for "foo"}] '(js/React.DOM.label #js {:htmlFor "foo"})))
   (testing "boolean attributes"
     (are-html-expanded
      '[:input {:type "checkbox" :checked true}]
@@ -210,8 +215,8 @@
    '[:li
      [:a {:href (str "#show/" (:key datum))}]
      [:div {:id (str "item" (:key datum))
-            :className ["class1" "class2"]}
-      [:span {:className "anchor"} (:name datum)]]]
+            :class ["class1" "class2"]}
+      [:span {:class "anchor"} (:name datum)]]]
    '(js/React.DOM.li
      nil
      (js/React.DOM.a
@@ -220,11 +225,11 @@
       #js {:id (str "item" (:key datum)), :className "class1 class2"}
       (js/React.DOM.span #js {:className "anchor"} (sablono.interpreter/interpret (:name datum)))))))
 
-(deftest test-issue-2-merge-classname
+(deftest test-issue-2-merge-class
   (are-html-expanded
-   '[:div.a {:className (if (true? true) "true" "false")}]
+   '[:div.a {:class (if (true? true) "true" "false")}]
    '(js/React.DOM.div #js {:className (sablono.util/join-classes ["a" (if (true? true) "true" "false")])})
-   '[:div.a.b {:className (if (true? true) ["true"] "false")}]
+   '[:div.a.b {:class (if (true? true) ["true"] "false")}]
    '(js/React.DOM.div #js {:className (sablono.util/join-classes ["a" "b" (if (true? true) ["true"] "false")])})))
 
 (deftest test-issue-3-recursive-js-literal

--- a/test/sablono/core_test.cljs
+++ b/test/sablono/core_test.cljs
@@ -165,48 +165,48 @@
          "<input id=\"foo\" type=\"hidden\" name=\"foo\" value=\"bar\">")))
 
 (deftest test-hidden-field-with-extra-atts
-  (is (= (html-str (html/hidden-field {:className "classy"} :foo "bar"))
-         "<input id=\"foo\" class=\"classy\" type=\"hidden\" name=\"foo\" value=\"bar\">")))
+  (is (= (html-str (html/hidden-field {:class "classy"} :foo "bar"))
+         "<input id=\"foo\" type=\"hidden\" name=\"foo\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-text-field
   (is (= (html-str (html/text-field :foo))
          "<input id=\"foo\" type=\"text\" name=\"foo\">")))
 
 (deftest test-text-field-with-extra-atts
-  (is (= (html-str (html/text-field {:className "classy"} :foo "bar"))
-         "<input id=\"foo\" class=\"classy\" type=\"text\" name=\"foo\" value=\"bar\">")))
+  (is (= (html-str (html/text-field {:class "classy"} :foo "bar"))
+         "<input id=\"foo\" type=\"text\" name=\"foo\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-check-box
   (is (= (html-str (html/check-box :foo true))
          "<input id=\"foo\" type=\"checkbox\" name=\"foo\" value=\"true\" checked=\"true\">")))
 
 (deftest test-check-box-with-extra-atts
-  (is (= (html-str (html/check-box {:className "classy"} :foo true 1))
-         "<input id=\"foo\" class=\"classy\" type=\"checkbox\" name=\"foo\" value=\"1\" checked=\"true\">")))
+  (is (= (html-str (html/check-box {:class "classy"} :foo true 1))
+         "<input id=\"foo\" type=\"checkbox\" name=\"foo\" value=\"1\" checked=\"true\" class=\"classy\">")))
 
 (deftest test-password-field
   (is (= (html-str (html/password-field :foo "bar"))
          "<input id=\"foo\" type=\"password\" name=\"foo\" value=\"bar\">")))
 
 (deftest test-password-field-with-extra-atts
-  (is (= (html-str (html/password-field {:className "classy"} :foo "bar"))
-         "<input id=\"foo\" class=\"classy\" type=\"password\" name=\"foo\" value=\"bar\">")))
+  (is (= (html-str (html/password-field {:class "classy"} :foo "bar"))
+         "<input id=\"foo\" type=\"password\" name=\"foo\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-email-field
   (is (= (html-str (html/email-field :foo "bar"))
          "<input id=\"foo\" type=\"email\" name=\"foo\" value=\"bar\">")))
 
 (deftest test-email-field-with-extra-atts
-  (is (= (html-str (html/email-field {:className "classy"} :foo "bar"))
-         "<input id=\"foo\" class=\"classy\" type=\"email\" name=\"foo\" value=\"bar\">")))
+  (is (= (html-str (html/email-field {:class "classy"} :foo "bar"))
+         "<input id=\"foo\" type=\"email\" name=\"foo\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-radio-button
   (is (= (html-str (html/radio-button :foo true 1))
          "<input id=\"foo-1\" type=\"radio\" name=\"foo\" value=\"1\" checked=\"true\">")))
 
 (deftest test-radio-button-with-extra-atts
-  (is (= (html-str (html/radio-button {:className "classy"} :foo true 1))
-         "<input id=\"foo-1\" class=\"classy\" type=\"radio\" name=\"foo\" value=\"1\" checked=\"true\">")))
+  (is (= (html-str (html/radio-button {:class "classy"} :foo true 1))
+         "<input id=\"foo-1\" type=\"radio\" name=\"foo\" value=\"1\" checked=\"true\" class=\"classy\">")))
 
 ;; (deftest test-select-options
 ;;   (are [x y] (= (html-str x) y)
@@ -237,8 +237,8 @@
 ;;   (let [options ["op1" "op2"]
 ;;         selected "op1"
 ;;         select-options (html-str (select-options options selected))]
-;;     (is (= (html-str (drop-down {:className "classy"} :foo options selected))
-;;            (str "<select class=\"classy\" id=\"foo\" name=\"foo\">"
+;;     (is (= (html-str (drop-down {:class "classy"} :foo options selected))
+;;            (str "<select id=\"foo\" name=\"foo\" class=\"classy\">"
 ;;                 select-options "</select>")))))
 
 (deftest test-text-area
@@ -246,8 +246,8 @@
          "<textarea id=\"foo\" name=\"foo\" value=\"bar\">bar</textarea>")))
 
 (deftest test-text-area-field-with-extra-atts
-  (is (= (html-str (html/text-area {:className "classy"} :foo "bar"))
-         "<textarea id=\"foo\" class=\"classy\" name=\"foo\" value=\"bar\">bar</textarea>")))
+  (is (= (html-str (html/text-area {:class "classy"} :foo "bar"))
+         "<textarea id=\"foo\" name=\"foo\" class=\"classy\" value=\"bar\">bar</textarea>")))
 
 (deftest test-text-area-escapes
   (is (= (html-str (html/text-area :foo "bar</textarea>"))
@@ -258,32 +258,32 @@
          "<input id=\"foo\" type=\"file\" name=\"foo\">")))
 
 (deftest test-file-field-with-extra-atts
-  (is (= (html-str (html/file-upload {:className "classy"} :foo))
-         "<input id=\"foo\" class=\"classy\" type=\"file\" name=\"foo\">")))
+  (is (= (html-str (html/file-upload {:class "classy"} :foo))
+         "<input id=\"foo\" type=\"file\" name=\"foo\" class=\"classy\">")))
 
 (deftest test-label
   (is (= (html-str (html/label :foo "bar"))
          "<label for=\"foo\"><span>bar</span></label>")))
 
 (deftest test-label-with-extra-atts
-  (is (= (html-str (html/label {:className "classy"} :foo "bar"))
-         "<label class=\"classy\" for=\"foo\"><span>bar</span></label>")))
+  (is (= (html-str (html/label {:class "classy"} :foo "bar"))
+         "<label for=\"foo\" class=\"classy\"><span>bar</span></label>")))
 
 (deftest test-submit
   (is (= (html-str (html/submit-button "bar"))
          "<input type=\"submit\" value=\"bar\">")))
 
 (deftest test-submit-button-with-extra-atts
-  (is (= (html-str (html/submit-button {:className "classy"} "bar"))
-         "<input class=\"classy\" type=\"submit\" value=\"bar\">")))
+  (is (= (html-str (html/submit-button {:class "classy"} "bar"))
+         "<input type=\"submit\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-reset-button
   (is (= (html-str (html/reset-button "bar"))
          "<input type=\"reset\" value=\"bar\">")))
 
 (deftest test-reset-button-with-extra-atts
-  (is (= (html-str (html/reset-button {:className "classy"} "bar"))
-         "<input class=\"classy\" type=\"reset\" value=\"bar\">")))
+  (is (= (html-str (html/reset-button {:class "classy"} "bar"))
+         "<input type=\"reset\" value=\"bar\" class=\"classy\">")))
 
 (deftest test-form-to
   (is (= (html-str (html/form-to [:post "/path"] "foo" "bar"))
@@ -296,8 +296,8 @@
               "<span>foo</span><span>bar</span></form>"))))
 
 (deftest test-form-to-with-extr-atts
-  (is (= (html-str (html/form-to {:className "classy"} [:post "/path"] "foo" "bar"))
-         "<form class=\"classy\" method=\"POST\" action=\"/path\"><span>foo</span><span>bar</span></form>")))
+  (is (= (html-str (html/form-to {:class "classy"} [:post "/path"] "foo" "bar"))
+         "<form method=\"POST\" action=\"/path\" class=\"classy\"><span>foo</span><span>bar</span></form>")))
 
 (deftest test-with-group
   (testing "hidden-field"
@@ -335,14 +335,14 @@
            "<label for=\"foo-bar\"><span>Bar</span></label><input id=\"foo-var\" type=\"text\" name=\"foo[var]\">"))))
 
 (deftest test-merge-attributes-let
-  (let [classes (merge {:id "a"} {:className "b"})]
+  (let [classes (merge {:id "a"} {:class "b"})]
     (is (= "<div id=\"a\" class=\"b\">content</div>" (html-str [:div classes "content"])))))
 
-(deftest test-issue-2-merge-classname
+(deftest test-issue-2-merge-class
   (is (= "<div class=\"a true\"></div>"
-         (html-str [:div.a {:className (if (true? true) "true" "false")}])))
+         (html-str [:div.a {:class (if (true? true) "true" "false")}])))
   (is (= "<div class=\"a b true\"></div>"
-         (html-str [:div.a.b {:className (if (true? true) ["true"] "false")}]))))
+         (html-str [:div.a.b {:class (if (true? true) ["true"] "false")}]))))
 
 (deftest test-issue-3-recursive-js-value
   (is (= "<div class=\"interaction-row\" style=\"position:relative;\"></div>"

--- a/test/sablono/util_test.cljx
+++ b/test/sablono/util_test.cljx
@@ -12,17 +12,17 @@
     [] nil
     [{:a 1} {:b 2}]
     {:a 1 :b 2}
-    [{:a 1 :className :a} {:b 2 :className "b"} {:c 3 :className ["c"]}]
-    {:a 1 :b 2 :c 3 :className [:a "b" "c"]}))
+    [{:a 1 :class :a} {:b 2 :class "b"} {:c 3 :class ["c"]}]
+    {:a 1 :b 2 :c 3 :class [:a "b" "c"]}))
 
 (deftest test-normalize-element
   (are [element expected]
     (is (= expected (u/normalize-element element)))
     [:div] ["div" {} nil]
     [:div#foo] ["div" {:id "foo"} nil]
-    [:div.foo] ["div" {:className ["foo"]} nil]
-    [:div.a.b] ["div" {:className ["a" "b"]} nil]
-    [:div.a.b {:className "c"}] ["div" {:className ["a" "b" "c"]} nil]))
+    [:div.foo] ["div" {:class ["foo"]} nil]
+    [:div.a.b] ["div" {:class ["a" "b"]} nil]
+    [:div.a.b {:class "c"}] ["div" {:class ["a" "b" "c"]} nil]))
 
 (deftest test-react-symbol
   (are [tag expected]


### PR DESCRIPTION
This is in reference to issue #5. I moved all ClojureScript code to use HTML attributes, for compatibility with hiccup and its derivatives, e.g. using `:for` instead of `:htmlFor`.

The bulk of the changes were in `sablono.compiler`, with the rest being merely updating keys across tests and other files.

After some research, I noticed there's three types of transformations between HTML and DOM attribute names:
1. The two special cases; `for` and `class`
2. Dasherized attributes; e.g. `http-equiv` and custom `data-*` attributes
3. Camelcase attributes; e.g. `onFocus`

The first category required a custom rewrite to `:htmlFor` and `:className`, respectively. The second category is handled with a dasherized-to-camelcase filter. The third category need not be handled at all, since HTML5 attributes are case-insensitive so we can just use camelcase in both HTML and DOM based code.
