### PR TITLE
react.js doesn't recognize camel case data-* attrs

### DIFF
--- a/src/sablono/util.cljx
+++ b/src/sablono/util.cljx
@@ -24,7 +24,7 @@
   "Returns camelcased version of the key, e.g. :http-equiv becomes :httpEquiv."
   [k]
   (let [[first-word & words] (split (name k) #"-")]
-    (if (empty? words)
+    (if (or (empty? words) (= first-word "data"))
       k
       (-> (map capitalize words)
           (conj first-word)

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -141,7 +141,8 @@
   (testing "attributes are converted to their DOM equivalents"
     (are-html-expanded
      '[:div {:class "classy"}] '(js/React.DOM.div #js {:className "classy"})
-     '[:div {:data-foo-bar "baz"}] '(js/React.DOM.div #js {:dataFooBar "baz"})
+     '[:div {:data-foo-bar "baz"}] '(js/React.DOM.div #js {:data-foo-bar "baz"})
+     '[:div {:content-editable "baz"}] '(js/React.DOM.div #js {:contentEditable "baz"})
      '[:label {:for "foo"}] '(js/React.DOM.label #js {:htmlFor "foo"})))
   (testing "boolean attributes"
     (are-html-expanded

--- a/test/sablono/util_test.cljx
+++ b/test/sablono/util_test.cljx
@@ -99,3 +99,10 @@
     "<div>x</div>" "x"
     "<div><div>x</div></div>" "<div>x</div>"
     " <div id=\"a\">\n<div>x</div></div> " "<div>x</div>"))
+
+(deftest test-camelcase
+  (are [attr expected]
+    (is (= expected (u/camelcase-key attr)))
+    :foo-bar :fooBar
+    :data-stuff :data-stuff
+    ))


### PR DESCRIPTION
sablono transforms data-\* attrs to camel case, and they then get ignored by react and are absent from the DOM

this patch treats data-\* attrs specially, and does not transform them to camel case : data-\* attributes are now present in the resulting DOM

i haven't tested it, but it may be that aria-\* attributes require similar treatment ( since they are lumped together with data-\* attributes here : http://facebook.github.io/react/docs/tags-and-attributes.html )
