### PR TITLE
Add support for React Devtools

### DIFF
--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -8,10 +8,11 @@
 ;; Taken from om, to hack around form elements.
 
 #+cljs
-(defn wrap-form-element [ctor]
+(defn wrap-form-element [ctor react-name]
   (js/React.createClass
    #js
-   {:getInitialState
+   {:displayName react-name
+    :getInitialState
     (fn []
       (this-as this #js {:value (aget (.-props this) "value")}))
     :onChange
@@ -36,10 +37,13 @@
                    :children (aget (.-props this) "children")}))))}))
 
 #+cljs
-(def input (wrap-form-element js/React.DOM.input))
+(def input (wrap-form-element js/React.DOM.input "OmInput"))
 
 #+cljs
-(def textarea (wrap-form-element js/React.DOM.textarea))
+(def textarea (wrap-form-element js/React.DOM.textarea "OmTextarea"))
+
+#+cljs
+(def option (wrap-form-element js/React.DOM.option "OmOption"))
 
 #+cljs
 (defn dom-fn [tag]


### PR DESCRIPTION
User-defined Om components will display properly, but the Om-wrapped components need a :displayName key added. This PR adds them for the Om-wrapped inputs (OmInput, OmTextarea), and also adds OmOption.

This PR won't add any benefits until Om master is released, but it shouldn't cause any problems until then either.

Check out the React Devtools here: https://github.com/facebook/react-devtools
