### PR TITLE
Expand arguments to React DOM fns in interpreter.

### DIFF
--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -62,16 +62,16 @@
 (defn element
   "Render an element vector as a HTML element."
   [element]
-  (let [[tag attrs content] (normalize-element element)]
-    ((dom-fn tag)
-     (attributes attrs)
-     (cond
-      (and (sequential? content)
-           (= 1 (count content)))
-      (interpret (first content))
-      content
-      (interpret content)
-      :else nil))))
+  (let [[tag attrs content] (normalize-element element)
+        f (dom-fn tag)
+        js-attrs (attributes attrs)]
+    (cond
+     (and (sequential? content)
+          (= 1 (count content)))
+     (f js-attrs (interpret (first content)))
+     content
+     (apply f js-attrs (interpret content))
+     :else (f js-attrs nil))))
 
 (defn- interpret-seq [s]
   (into-array (map interpret s)))

--- a/test/sablono/interpreter_test.cljx
+++ b/test/sablono/interpreter_test.cljx
@@ -28,3 +28,34 @@
   (are [form expected]
     (is (= expected (html-str (i/interpret form))))
     [:#test.klass1] "<div id=\"test\" class=\"klass1\"></div>"))
+
+#+cljs
+(defn interpret-no-dynamic-children
+  "Same as `i/interpret` except disallows calling React DOM functions
+  with arrays as arguments. React will produce the same output for a
+  single array argument with multiple children as it will for those
+  children expanded into arguments. E.g., `React.DOM.div(null,
+  [React.DOM.div(null), React.DOM.div(null)])` produces the same
+  output as `React.DOM.div(null, React.DOM.div(null),
+  React.DOM.div(null))`, but the former produces a warning about
+  dynamic children and the latter does not. We'd like to check that
+  certain forms passed to `i/interpret` don't result in calls like the
+  latter, so we have to wrap `i/interpret` using this function."
+  [form]
+  (let [dom-fn i/dom-fn
+        wrapped (fn [tag]
+                  (let [f (dom-fn tag)]
+                    (fn [props & children]
+                      (if-let [bad-args (seq (filter #(array? %) children))]
+                        (throw (js/Error.
+                                   (str "some args to " tag
+                                        " are arrays (dynamic children): "
+                                        (pr-str bad-args))))
+                        (apply f props children)))))]
+    (with-redefs [i/dom-fn wrapped]
+      (i/interpret form))))
+
+#+cljs
+(deftest test-static-children-as-arguments
+  (testing "static children should interpret as direct React arguments"
+    (is (interpret-no-dynamic-children [:div [:div] [:div]]))))


### PR DESCRIPTION
The sablono compiler correctly splices in arguments to React DOM fns, but whenever >1 arguments are present, the interpreter passes them as an array rather than normal arguments. This triggers the [React dynamic children warning](http://facebook.github.io/react/docs/multiple-components.html#dynamic-children), even with static children, such as in the form `[:div [:div] [:div]]`.

Minimal example repo [here](https://github.com/jenanwise/sablono-interp-test/blob/master/src/sablono_interp_test/core.cljs). Note that under React 0.9.0, the first render _won't_ trigger the warning. See comments in the example repo.
### Existing behavior detail

Under the current master, sablono takes the following:

``` clojure
;; compiled
(html [:div [:div] [:div]])
```

and compiles it down to:

``` js
React.DOM.div(null, React.DOM.div(null), React.DOM.div(null))
```

However, if you force sablono to use its interpreter (such as by wrapping the markup in a bare `(let)`), sablono will call React with a single array of children rather than positional arguments. E.g.,

``` clojure
;; interpreted
(html (let [] [:div [:div] [:div]]))
```

results in a call that looks like

``` js
React.DOM.div(null, [React.DOM.div(null), React.DOM.div(null)])
```

This produces the same output as the compiled version, but triggers React's dynamic children warning.

You can see this difference in the [compiler code](https://github.com/r0man/sablono/blob/0338ca029df050fcecf2ce9db0522560a9ee5340/src/sablono/compiler.clj#L74), which splices in positional arguments, and the [interpreter code](https://github.com/r0man/sablono/blob/0338ca029df050fcecf2ce9db0522560a9ee5340/src/sablono/interpreter.cljx#L73), which does not splice and which does not currently use `(apply)`.
### Changes

This patch modifies the interpreter code to use `(apply)`, forcing the children elements to be positional arguments to the React DOM function and matching behavior of the compiler.
### Testing

Since output for positional vs array of children arguments to React DOM functions is identical, I added an interpreter test helper that throws when encountering array arguments to the React DOM fns returned by sablono's `(dom-fn)`. All other existing tests pass.
