### PR TITLE
Add support for subvec forms.

### DIFF
--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -95,6 +95,9 @@
   IndexedSeq
   (interpret [this]
     (interpret-seq this))
+  Subvec
+  (interpret [this]
+    (element this))
   PersistentVector
   (interpret [this]
     (element this))


### PR DESCRIPTION
In particular, these seem to be created by clojure.zip with hickory's hiccup.zip.
