### PR TITLE
Bump React version, and allow user to pick version

### DIFF
--- a/src/sablono/core.cljx
+++ b/src/sablono/core.cljx
@@ -83,7 +83,8 @@
 #+cljs
 (defn include-react
   "Include Facebook's React JavaScript library."
-  [] (include-js "http://fb.me/react-0.9.0.js"))
+  ([] (include-react "0.11.2"))
+  ([version] (include-js (str "http://fb.me/react-" version ".js"))))
 
 (defelem link-to
   "Wraps some content in a HTML hyperlink with the supplied URL."


### PR DESCRIPTION
Om now supports React 0.11.2. While bumping the version in the include-react function, we might as well also allow users to specify a specific React version if they don't want the default.