### PR TITLE
Update React dependencies, fix compat Om 0.8.2+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.facebook/react "0.12.2.1"]
+  :dependencies [[com.facebook/react "0.12.2.4"]
                  [org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2665" :scope "provided"]]
+                 [org.clojure/clojurescript "0.0-2727" :scope "provided"]]
   :aliases {"cleantest" ["do" "clean," "cljx" "once," "test," "cljsbuild" "test"]
             "deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]}
   :cljsbuild {:builds [{:id "dev"

--- a/src/sablono/core.cljx
+++ b/src/sablono/core.cljx
@@ -5,7 +5,8 @@
             [sablono.util :refer [as-str to-uri]]
             [sablono.interpreter :as interpreter]
             #+clj [sablono.compiler :as compiler]
-            #+cljs [goog.dom :as dom]))
+            #+cljs [goog.dom :as dom]
+            #+cljs com.facebook.React))
 
 (defmacro html
   "Render Clojure data structures via Facebook's React."

--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -1,7 +1,8 @@
 (ns sablono.interpreter
   (:require [clojure.string :refer [blank? join]]
             [sablono.util :refer [html-to-dom-attrs normalize-element]]
-            #+cljs [goog.object :as gobject]))
+            #+cljs [goog.object :as gobject]
+            #+cljs com.facebook.React))
 
 (defprotocol IInterpreter
   (interpret [this] "Interpret a Clojure data structure as a React fn call."))


### PR DESCRIPTION
CLJS 0.0-2719 introduces dependency declarations on JS packages, which
allows the CLJS compiler to sequence dependencies and compilation
without relying upon `cljsbuild` `:preamble` or `<script>` tag ordering.
Om 0.8.2 and later take advantage of this, and now recommend _not_
including React as a preamble/`<script>` tag, which unfortunately breaks
Sablono.

This commit upgrades Sablono to the new dependency declarations, which
makes it compatible with Om setups 0.8.2+.  You can see in the
compiled JS output that Sablono will now properly declare its
`goog.require` dependencies upon React.

There still may be additional declarations that can now be removed
from Sablono to clean up, but this will at least get Sablono working,
tested on CLJS 0.0-2727 and Om 0.8.4.

See more:

https://groups.google.com/forum/#!topic/clojurescript/pJ_EYHkYAUs