### PR TITLE
Switch to cljsjs react provider

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :min-lein-version "2.0.0"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[com.facebook/react "0.12.2.4"]
+  :dependencies [[cljsjs/react "0.12.2-5"]
                  [org.clojure/clojure "1.6.0"]
                  [org.clojure/clojurescript "0.0-2727" :scope "provided"]]
   :aliases {"cleantest" ["do" "clean," "cljx" "once," "test," "cljsbuild" "test"]
@@ -26,8 +26,7 @@
                                    ;; :optimizations :whitespace
                                    :pretty-print true
                                    :preamble ["jquery.js"
-                                              "phantomjs-shims.js"
-                                              "react/react.min.js"]
+                                              "phantomjs-shims.js"]
                                    :externs ["externs/hickory.js"
                                              "externs/jquery-1.9.js"]}}]
               :test-commands {"phantom" ["phantomjs" :cljs.test/runner "target/test/sablono.js"]}}

--- a/src/sablono/core.cljx
+++ b/src/sablono/core.cljx
@@ -6,7 +6,7 @@
             [sablono.interpreter :as interpreter]
             #+clj [sablono.compiler :as compiler]
             #+cljs [goog.dom :as dom]
-            #+cljs com.facebook.React))
+            #+cljs cljsjs.react))
 
 (defmacro html
   "Render Clojure data structures via Facebook's React."

--- a/src/sablono/interpreter.cljx
+++ b/src/sablono/interpreter.cljx
@@ -2,7 +2,7 @@
   (:require [clojure.string :refer [blank? join]]
             [sablono.util :refer [html-to-dom-attrs normalize-element]]
             #+cljs [goog.object :as gobject]
-            #+cljs com.facebook.React))
+            #+cljs cljsjs.react))
 
 (defprotocol IInterpreter
   (interpret [this] "Interpret a Clojure data structure as a React fn call."))


### PR DESCRIPTION
Om is using cljsjs as react provider and it causes a conflict in advanced compilation mode, because React is defined twice (in cljsjs.react and in com.facebook/react).