### PR TITLE
Macroexpand forms during compilation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sablono "0.3.2-SNAPSHOT"
+(defproject sablono "0.3.3-SNAPSHOT"
   :description "Lisp style templating for Facebook's React."
   :url "http://github.com/r0man/sablono"
   :author "r0man"
@@ -7,7 +7,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[cljsjs/react "0.12.2-5"]
                  [org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2816" :scope "provided"]]
+                 [org.clojure/clojurescript "0.0-2843" :scope "provided"]]
   :aliases {"cleantest" ["do" "clean," "cljx" "once," "test," "cljsbuild" "test"]
             "deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]}
   :cljsbuild {:builds [{:id "dev"
@@ -45,14 +45,13 @@
   :deploy-repositories [["releases" :clojars]]
   :prep-tasks [["cljx" "once"]]
   :profiles {:dev {:dependencies [[crate "0.2.5"]
+                                  [com.cemerick/piggieback "0.1.6-SNAPSHOT"]
                                   [hickory "0.5.4"]
                                   [org.clojure/tools.nrepl "0.2.7"]
                                   [reagent "0.4.3"]]
                    :plugins [[com.keminglabs/cljx "0.5.0"]
-                             [com.cemerick/austin "0.1.7-SNAPSHOT"]
                              [com.cemerick/clojurescript.test "0.3.3"]
                              [lein-cljsbuild "1.0.4"]]
-                   :repl-options {:nrepl-middleware [cljx.repl-middleware/wrap-cljx]}
                    :resource-paths ["test-resources"]
                    :source-paths ["target/classes"]
                    :test-paths ["test" "target/test-classes"]}})

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -258,7 +258,23 @@
              (clojure.core/remove
               clojure.core/nil?
               (if (clojure.core/map? attrs)
-                [] [(sablono.interpreter/interpret attrs)]))))))
+                [] [(sablono.interpreter/interpret attrs)]))))
+     '(let [] (when true [:span "foo"]))
+     '(let* [] (if true (do (js/React.createElement "span" nil "foo"))))
+     '(letfn [(foo [] true)]
+        (when (foo)
+          [:span "bar"]))
+     '(letfn* [foo (clojure.core/fn foo [] true)]
+              (if (foo) (do (js/React.createElement "span" nil "bar"))))
+     '(do [:div "should not be optimized"]
+          (let []
+            (when true
+              [:div "should be optimized"])))
+     '(do [:div "should not be optimized"]
+          (let* []
+                (if true
+                  (do (js/React.createElement "div" nil
+                                              "should be optimized")))))))
   (testing "values are evaluated only once"
     (let [times-called (atom 0)
           foo #(swap! times-called inc)]


### PR DESCRIPTION
Hello, 

I don't expect you to accept this PR as is; I mostly just want to propose this enhancement to hear your thoughts. 

Essentially my goal here is twofold: 

1. Optimize let bodies who might contain vector literals or other compile-time optimizable forms. 
2. Allow forms such as (when test then) to expand into (if test then nil) and thusly be optimizable.