### PR TITLE
Update doc to include info about setting innerHTML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ this in *Ŝablono*:
 		:type "text"}])
 ```
 
+## innerHTML (*Unsafe*)
+
+It is *really* not recommended to directly set the innerHTML
+attribute, but in rare cases it is necessary. i.e. injecting a
+html string that was generated from Markdown.
+
+``` clj
+(html [:div
+	   {:dangerouslySetInnerHTML {:__html my-content-string }}])
+```
+You can read more at [React's special attributes](http://facebook.github.io/react/docs/special-non-dom-attributes.html).
+
 ## Thanks
 
 This library is based on James Reeves [Hiccup](https://github.com/weavejester/hiccup) library.


### PR DESCRIPTION
I needed this when I was mixing some rendered markdown into some Sablono code.  It took me a bit to find #36 , and the exact syntax wasn't immediately clear from the issue.

Thanks, and great job on Sablono!  This was the *only* Sablono issue I had when I needed to put together a complex project on a very short timeline.