### PR TITLE
Fixed throw on expansion of fn call with namespace with dot

### DIFF
--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -121,10 +121,13 @@
 
 (defmethod compile-form :default
   [expr]
-  (let [mform (macroexpand expr)]
-    (if (= mform expr)
-      `(sablono.interpreter/interpret ~expr)
-      (compile-form mform))))
+  (try
+    (let [mform (macroexpand expr)]
+      (if (= mform expr)
+        `(sablono.interpreter/interpret ~expr)
+        (compile-form mform)))
+    (catch ClassNotFoundException e
+      `(sablono.interpreter/interpret ~expr))))
 
 (defn- not-hint?
   "True if x is not hinted to be the supplied type."

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -384,3 +384,12 @@
    '(js/React.createElement "div" #js {:id "test" :className "klass1 klass2"})
    '[:.klass1.klass2#test]
    '(js/React.createElement "div" #js {:id "test" :className "klass1 klass2"})))
+
+(deftest test-namespaced-fn-call
+  (are-html-expanded
+    '(some-ns/comp "arg")
+    '(sablono.interpreter/interpret (some-ns/comp "arg"))
+   
+    '(some.ns/comp "arg")
+    '(sablono.interpreter/interpret (some.ns/comp "arg"))))
+    


### PR DESCRIPTION
Right now this code does not work:

```
(sablono.core/html (some.ns/some-fn))
```

problem lies somewhere here:
https://github.com/clojure/clojure/blob/clojure-1.7.0/src/jvm/clojure/lang/Compiler.java#L6662
https://github.com/clojure/clojure/blob/clojure-1.7.0/src/jvm/clojure/lang/Compiler.java#L1016-L1017

Long story short, Clojure’s `macroexpand` when it sees a namespace with a dot tries to load a class with such a name (try `(macroexpand '(bla.bla/fun))`, compare to `(macroexpand '(blabla/fun))`).

Sablono compiler relies on `macroexpand` to check if form needs to be future expanded. It makes it impossible to call functions using dotted namespaces inside `html` macro. As I understand it, it’s just an optimisation and we can always fall back to interpreter if something went wrong.

This patch wraps `macroexpand` into try/catch are falls back to interpreter.