### PR TITLE
Preserve order of CSS classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Master (unreleased)
+
+### Changes
+
+* [#98](https://github.com/r0man/sablono/issues/98) Preserve CSS class order

--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -32,9 +32,6 @@
          (keyword? value)
          (string? value))
      value
-     (and (sequential? value)
-          (= 1 (count value)))
-     (first value)
      (and (or (sequential? value)
               (set? value))
           (every? string? value))

--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -74,7 +74,7 @@
    (defn attributes [attrs]
      (let [attrs (clj->js (util/html-to-dom-attrs attrs))
            class (.-className attrs)
-           class (if (array? class) (join " " (sort class)) class)]
+           class (if (array? class) (join " " class) class)]
        (if (blank? class)
          (js-delete attrs "className")
          (set! (.-className attrs) class))

--- a/src/sablono/normalize.cljc
+++ b/src/sablono/normalize.cljc
@@ -22,7 +22,7 @@
     :else x))
 
 (defn class
-  "Normalize `class` into a set of classes."
+  "Normalize `class` into a vector of classes."
   [class]
   (cond
     (nil? class)
@@ -30,27 +30,29 @@
 
     (list? class)
     (if (symbol? (first class))
-      #{class}
-      (set (map class-name class)))
+      [class]
+      (map class-name class))
 
     (symbol? class)
-    #{class}
+    [class]
 
     (string? class)
-    #{class}
+    [class]
 
     (keyword? class)
-    #{(class-name class)}
+    [(class-name class)]
+
     (and (or (set? class)
              (sequential? class))
          (every? #(or (keyword? %)
                       (string? %))
                  class))
-    (apply sorted-set (map class-name class))
+    (mapv class-name class)
 
     (and (or (set? class)
              (sequential? class)))
-    (set (map class-name class))
+    (mapv class-name class)
+
     :else class))
 
 (defn attributes
@@ -64,8 +66,8 @@
   "Like clojure.core/merge but concatenate :class entries."
   [& maps]
   (let [maps (map attributes maps)
-        classes (map #(into #{} %) (map :class maps))
-        classes (apply set/union classes)]
+        classes (map :class maps)
+        classes (vec (dedupe (apply concat classes)))]
     (cond-> (apply merge maps)
       (not (empty? classes))
       (assoc :class classes))))

--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -59,7 +59,13 @@
 (defn join-classes
   "Join the `classes` with a whitespace."
   [classes]
-  (join " " (sort (flatten (seq classes)))))
+  (->> (map #(cond
+               (string? %) %
+               :else (seq %))
+            classes)
+       (flatten)
+       (dedupe)
+       (join " ")))
 
 (defn wrapped-type?
   "Return true if the element `type` needs to be wrapped."

--- a/test/sablono/core_test.cljs
+++ b/test/sablono/core_test.cljs
@@ -504,7 +504,7 @@
   (is (= (let [input-classes ["large" "big"]]
            (html-vec [:input.form-control
                       (merge {:class input-classes})]))
-         [:input {:class "big form-control large"}])))
+         [:input {:class "form-control large big"}])))
 
 (deftest test-issue-33-number-warning
   (is (= (html-vec [:div (count [1 2 3])])
@@ -534,6 +534,35 @@
   (is (= (html-vec [:div.a {:class #{"a" "b" "c"}}])
          [:div {:class "a b c"}])))
 
+
+(deftest test-class-duplication
+  (is (= (html-vec [:div.a.a.b.b.c {:class "c"}])
+         [:div {:class "a b c"}]))  )
+
+(deftest test-class-order
+  (is (= (html-vec [:div.a.b.c {:class "d"}])
+         [:div {:class "a b c d"}]))
+  (is (= (html-vec [:div.a.b.c {:class ["foo" "bar"]}])
+         [:div {:class "a b c foo bar"}])))
+
+(deftest test-class-as-set
+  (is (= (html-vec [:div.a {:class #{"a" "b" "c"}}])
+         [:div {:class "a b c"}]))
+  (is (= (html-vec [:div.a {:class (set ["a" "b" "c"])}])
+         [:div {:class "a b c"}])))
+
+(deftest test-class-as-list
+  (is (= (html-vec [:div.a {:class '("a" "b" "c")}])
+         [:div {:class "a b c"}]))
+  (is (= (html-vec [:div.a {:class (list "a" "b" "c")}])
+         [:div {:class "a b c"}])))
+
+(deftest test-class-as-vector
+  (is (= (html-vec [:div.a {:class ["a" "b" "c"]}])
+         [:div {:class "a b c"}]))
+  (is (= (html-vec [:div.a {:class (vector "a" "b" "c")}])
+         [:div {:class "a b c"}])))
+
 (deftest test-issue-80
   (is (= (html-vec
           [:div
@@ -552,15 +581,19 @@
            (do
              [:div {:class (vector "foo" "bar")}])])
          [:div {}
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]])))
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]])))
 
 (deftest test-issue-90
   (is (= (html-vec [:div nil (case :a :a "a")])
          [:div {} "a"])))
+
+(deftest test-complex-scenario
+  (is (= (html-vec [:div.a {:class (list "b")} (case :a :a "a")])
+         [:div {:class "a b"} "a"])))

--- a/test/sablono/interpreter_test.cljs
+++ b/test/sablono/interpreter_test.cljs
@@ -92,14 +92,14 @@
            (do
              [:div {:class (vector "foo" "bar")}])])
          [:div {}
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]
-          [:div {:class "bar foo"}]])))
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]
+          [:div {:class "foo bar"}]])))
 
 (deftest test-issue-90
   (is (= (interpret [:div nil (case :a :a "a")])

--- a/test/sablono/normalize_test.cljc
+++ b/test/sablono/normalize_test.cljc
@@ -21,11 +21,11 @@
     [{:a 1} {:b 2}]
     {:a 1 :b 2}
     [{:a 1 :class :a} {:b 2 :class "b"} {:c 3 :class ["c"]}]
-    {:a 1 :b 2 :c 3 :class #{"a" "b" "c"}}
+    {:a 1 :b 2 :c 3 :class ["a" "b" "c"]}
     [{:a 1 :class :a} {:b 2 :class "b"} {:c 3 :class (seq ["c"])}]
-    {:a 1 :b 2 :c 3 :class #{"a" "b" "c"}}
-    ['{:a 1 :class #{"a"}} '{:b 2 :class #{(if true "b")}}]
-    '{:a 1 :class #{"a" (if true "b")} :b 2}))
+    {:a 1 :b 2 :c 3 :class ["a" "b" "c"]}
+    ['{:a 1 :class ["a"]} '{:b 2 :class [(if true "b")]}]
+    '{:a 1 :class ["a" (if true "b")] :b 2}))
 
 (deftest test-strip-css
   (are [x expected]
@@ -56,13 +56,13 @@
   (are [class expected]
       (= expected (normalize/class class))
     nil nil
-    :x #{"x"}
-    "x" #{"x"}
-    ["x"] #{"x"}
-    [:x] #{"x"}
-    '(if true "x") #{'(if true "x")}
-    'x #{'x}
-    '("a" "b") #{"a" "b"}))
+    :x ["x"]
+    "x" ["x"]
+    ["x"] ["x"]
+    [:x] ["x"]
+    '(if true "x") ['(if true "x")]
+    'x ['x]
+    '("a" "b") ["a" "b"]))
 
 (deftest test-attributes
   (are [attrs expected]
@@ -70,9 +70,9 @@
     nil nil
     {} {}
     {:class nil} {:class nil}
-    {:class "x"} {:class #{"x"}}
-    {:class #{"x"}} {:class #{"x"}}
-    '{:class #{"x" (if true "y")}} '{:class #{(if true "y") "x"}}))
+    {:class "x"} {:class ["x"]}
+    {:class ["x"]} {:class ["x"]}
+    '{:class ["x" (if true "y")]} '{:class ["x" (if true "y")]}))
 
 (deftest test-children
   (are [children expected]
@@ -93,7 +93,7 @@
     [:div] ["div" {} '()]
     [:div {:class nil}] ["div" {:class nil} '()]
     [:div#foo] ["div" {:id "foo"} '()]
-    [:div.foo] ["div" {:class #{"foo"}} '()]
-    [:div.a.b] ["div" {:class #{"a" "b"}} '()]
-    [:div.a.b {:class "c"}] ["div" {:class #{"a" "b" "c"}} '()]
-    [:div.a.b {:class nil}] ["div" {:class #{"a" "b"}} '()]))
+    [:div.foo] ["div" {:class ["foo"]} '()]
+    [:div.a.b] ["div" {:class ["a" "b"]} '()]
+    [:div.a.b {:class "c"}] ["div" {:class ["a" "b" "c"]} '()]
+    [:div.a.b {:class nil}] ["div" {:class ["a" "b"]} '()]))

--- a/test/sablono/util_test.cljc
+++ b/test/sablono/util_test.cljc
@@ -41,6 +41,16 @@
   (is (not (u/element? 1)))
   (is (not (u/element? "x"))))
 
+(deftest test-join-classes
+  (are [classes expected]
+      (= expected (u/join-classes classes))
+    ["a"] "a"
+    #{"a"} "a"
+    ["a" "b"] "a b"
+    #{"a" "b"} "a b"
+    ["a" ["b"]] "a b"
+    ["a" (set ["a" "b" "c"])] "a b c"))
+
 #?(:cljs
    (deftest test-as-str
      (are [args expected]


### PR DESCRIPTION
The order of CSS classes matters
see http://stackoverflow.com/questions/15670631/does-the-order-of-classes-listed-on-an-item-affect-the-css

Change the underlying representation from sets to vectors

Adopt the convention : :className comes after the keywordized CSS classes.
ie. [:div.a.b {:className "c d"}] ;;=> "a b c d"

Deduplicate the same classes
ie. [:div.a.b.b {:className "c d"}] ;;=> "a b c d"