### PR TITLE
Make react-dom-server dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0
+
+* [#100](https://github.com/r0man/sablono/issues/100) Move the
+  `render` and `render-static` functions into the `sablono.server`
+  namespace, to make the dependency on `react-dom-server` optional.
+
 ## 0.5.4
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Via Clojars: https://clojars.org/sablono
 ``` clj
 [cljsjs/react "0.14.3-0"]
 [cljsjs/react-dom "0.14.3-1"]
+```
+
+If you want to do server rendering and use the `render` or
+`render-static` functions from the `sablono.server` namespace you need
+to add the following dependency as well:
+
+``` clj
 [cljsjs/react-dom-server "0.14.3-0"]
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject sablono "0.5.5-SNAPSHOT"
+(defproject sablono "0.6.0-SNAPSHOT"
   :description "Lisp style templating for Facebook's React."
   :url "http://github.com/r0man/sablono"
   :author "r0man"

--- a/src/sablono/core.cljs
+++ b/src/sablono/core.cljs
@@ -7,8 +7,7 @@
             [sablono.interpreter :as interpreter]
             [goog.dom :as dom]
             [cljsjs.react]
-            [cljsjs.react.dom]
-            [cljsjs.react.dom.server]))
+            [cljsjs.react.dom]))
 
 (defn wrap-attrs
   "Add an optional attribute argument to a function that returns a element vector."
@@ -24,18 +23,6 @@
 (defn- update-arglists [arglists]
   (for [args arglists]
     (vec (cons 'attr-map? args))))
-
-(defn render
-  "Render `element` as HTML string."
-  [element]
-  (if element
-    (js/ReactDOMServer.renderToString element)))
-
-(defn render-static
-  "Render `element` as HTML string, without React internal attributes."
-  [element]
-  (if element
-    (js/ReactDOMServer.renderToStaticMarkup element)))
 
 (defn include-css
   "Include a list of external stylesheet files."

--- a/src/sablono/server.cljs
+++ b/src/sablono/server.cljs
@@ -1,0 +1,14 @@
+(ns sablono.server
+  (:require [cljsjs.react.dom.server]))
+
+(defn render
+  "Render `element` as HTML string."
+  [element]
+  (if element
+    (js/ReactDOMServer.renderToString element)))
+
+(defn render-static
+  "Render `element` as HTML string, without React internal attributes."
+  [element]
+  (if element
+    (js/ReactDOMServer.renderToStaticMarkup element)))

--- a/test/sablono/core_test.cljs
+++ b/test/sablono/core_test.cljs
@@ -10,15 +10,8 @@
             [hickory.core :as hickory]
             [goog.dom :as gdom]
             [sablono.core :as html :include-macros true]
-            [sablono.util :refer [to-str]]))
-
-(deftest test-render
-  (are [markup match]
-      (is (re-matches (re-pattern match) (html/render markup)))
-    (html [:div#a.b "c"])
-    "<div id=\"a\" class=\"b\" data-reactid=\".*\" data-react-checksum=\".*\">c</div>"
-    (html [:div (when true [:p "data"]) (if true [:p "data"] nil)])
-    "<div data-reactid=\".*\" data-react-checksum=\".*\"><p data-reactid=\".*\">data</p><p data-reactid=\".*\">data</p></div>"))
+            [sablono.util :refer [to-str]]
+            [sablono.server :as server]))
 
 (deftest test-tag-names
   (testing "basic tags"

--- a/test/sablono/interpreter_test.cljs
+++ b/test/sablono/interpreter_test.cljs
@@ -4,11 +4,12 @@
   (:require [cljs.test :as t]
             [devcards.core :refer-macros [deftest]]
             [sablono.core :as c]
-            [sablono.interpreter :as i]))
+            [sablono.interpreter :as i]
+            [sablono.server :as server]))
 
 (defn interpret [x]
   (some->> (i/interpret x)
-           (c/render-static)
+           (server/render-static)
            (hickory.core/parse-fragment)
            (map hickory.core/as-hiccup)
            (first)))

--- a/test/sablono/server_test.cljs
+++ b/test/sablono/server_test.cljs
@@ -1,0 +1,20 @@
+(ns sablono.server-test
+  (:require [cljs.test :as t :refer-macros [are deftest]]
+            [sablono.core :refer-macros [html]]
+            [sablono.server :as server]))
+
+(deftest test-render
+  (are [markup match]
+      (re-matches (re-pattern match) (server/render markup))
+    (html [:div#a.b "c"])
+    "<div id=\"a\" class=\"b\" data-reactid=\".*\" data-react-checksum=\".*\">c</div>"
+    (html [:div (when true [:p "data"]) (if true [:p "data"] nil)])
+    "<div data-reactid=\".*\" data-react-checksum=\".*\"><p data-reactid=\".*\">data</p><p data-reactid=\".*\">data</p></div>"))
+
+(deftest test-render-static
+  (are [markup expected]
+      (= expected (server/render-static markup))
+    (html [:div#a.b "c"])
+    "<div id=\"a\" class=\"b\">c</div>"
+    (html [:div (when true [:p "data"]) (if true [:p "data"] nil)])
+    "<div><p>data</p><p>data</p></div>"))

--- a/test/sablono/test.clj
+++ b/test/sablono/test.clj
@@ -2,7 +2,7 @@
   (:require [sablono.core]))
 
 (defmacro html-str [element]
-  `(sablono.core/render-static
+  `(sablono.server/render-static
     (sablono.core/html ~element)))
 
 (defmacro html-vec [element]
@@ -13,5 +13,5 @@
 
 (defmacro are-html [& contents]
   `(are [html# expected#]
-     (= (sablono.test/html-vec html#) expected# )
+       (= (sablono.test/html-vec html#) expected# )
      ~@contents))

--- a/test/sablono/test.cljs
+++ b/test/sablono/test.cljs
@@ -4,10 +4,12 @@
             [sablono.core-test]
             [sablono.interpreter-test]
             [sablono.normalize-test]
+            [sablono.server-test]
             [sablono.util-test]))
 
 (doo-tests 'sablono.core-test
            'sablono.interpreter-test
            'sablono.normalize-test
+           'sablono.server-test
            'sablono.util-test
            'sablono.benchmark)


### PR DESCRIPTION
The `render` and `render-static` functions are moved into the
`sablono.server` namespace. `react-dom-server` is now an optional
dependency.