### PR TITLE
replace `dedupe` with `distinct`

### DIFF
--- a/src/sablono/normalize.cljc
+++ b/src/sablono/normalize.cljc
@@ -67,7 +67,7 @@
   [& maps]
   (let [maps (map attributes maps)
         classes (map :class maps)
-        classes (vec (dedupe (apply concat classes)))]
+        classes (vec (distinct (apply concat classes)))]
     (cond-> (apply merge maps)
       (not (empty? classes))
       (assoc :class classes))))

--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -64,7 +64,7 @@
                :else (seq %))
             classes)
        (flatten)
-       (dedupe)
+       (distinct)
        (join " ")))
 
 (defn wrapped-type?


### PR DESCRIPTION
`dedupe` is meant for sorted collections only

```
user=> (dedupe [1 2 2 3 2])
(1 2 3 2)
user=> (distinct [1 2 2 3 2])
(1 2 3)
```