### PR TITLE
Defmethod compile-element ::literal-tag-and-hinted-attributes

### DIFF
--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -226,8 +226,9 @@
      '(js/React.createElement "div" #js {:data-toggle "modal", :data-target "#modal"}))))
 
 (deftest compiled-tags
-  (testing "tag content can be vars"
-    (let [x "foo"]
+  (testing "tag content can be vars, and vars can be type-hinted with some metadata"
+    (let [x "foo"
+          y {:id "id"}]
       (are-html-expanded
        '[:span x]
        '(let* [attrs x]
@@ -237,8 +238,13 @@
              (sablono.interpreter/attributes attrs)
              nil)
            (if (clojure.core/map? attrs)
-             nil [(sablono.interpreter/interpret attrs)]))))))
-  (testing "tag content can be forms"
+             nil [(sablono.interpreter/interpret attrs)])))
+       '[:span ^:attrs y]
+       '(let* [attrs y]
+          (clojure.core/apply
+           js/React.createElement "span"
+           (sablono.interpreter/attributes attrs) nil)))))
+  (testing "tag content can be forms, and forms can be type-hinted with some metadata"
     (are-html-expanded
      '[:span (str (+ 1 1))]
      '(let* [attrs (str (+ 1 1))]
@@ -249,7 +255,12 @@
            nil)
          (if (clojure.core/map? attrs)
            nil [(sablono.interpreter/interpret attrs)])))
-     [:span ({:foo "bar"} :foo)] '(js/React.createElement "span" nil "bar")))
+     [:span ({:foo "bar"} :foo)] '(js/React.createElement "span" nil "bar")
+     '[:span ^:attrs (merge {:type "button"} attrs)]
+     '(let* [attrs (merge {:type "button"} attrs)]
+        (clojure.core/apply
+         js/React.createElement "span"
+         (sablono.interpreter/attributes attrs) nil))))
   (testing "attributes can contain vars"
     (let [id "id"]
       (are-html-expanded
@@ -459,15 +470,23 @@
            "ul" nil
            (into-array
             (clojure.core/for [n (range 3)]
-              (clojure.core/let
-                  [attrs n]
+              (clojure.core/let [attrs n]
                 (clojure.core/apply
                  js/React.createElement "li"
                  (if (clojure.core/map? attrs)
                    (sablono.interpreter/attributes attrs)
                    nil)
                  (if (clojure.core/map? attrs)
-                   nil [(sablono.interpreter/interpret attrs)])))))))))
+                   nil [(sablono.interpreter/interpret attrs)]))))))))
+  (is (= (compile [:ul (for [n (range 3)] [:li ^:attrs n])])
+         '(js/React.createElement
+           "ul" nil
+           (into-array
+            (clojure.core/for [n (range 3)]
+              (clojure.core/let [attrs n]
+                (clojure.core/apply
+                 js/React.createElement "li"
+                 (sablono.interpreter/attributes attrs) nil))))))))
 
 (deftest test-optimize-if
   (is (= (compile (if true [:span "foo"] [:span "bar"]) )


### PR DESCRIPTION
I think sablono can avoid some redundant type checking code with simple metadata hint, at runtime.

Here is some examples of rum component that its first arg `attrs` is always expected to be attribute data in cljs context.

```clojure
(macroexpand-1
 '(rum/defc button < rum/static
    [& [attrs content]]
    [:button.mdl-button.mdl-js-button attrs content])) ; no ^:attrs hint
(def button "" (clojure.core/let [render-mixin__4606__auto__ (rum.core/render->mixin (clojure.core/fn ([& [attrs content]] (do (clojure.core/let [attrs50227 attrs] (clojure.core/apply js/React.createElement "button" (if (clojure.core/map? attrs50227) (sablono.interpreter/attributes (sablono.normalize/merge-with-class {:class ["mdl-button" "mdl-js-button"]} attrs50227)) #js {:className "mdl-button mdl-js-button"}) (if (clojure.core/map? attrs50227) [(sablono.interpreter/interpret content)] [(sablono.interpreter/interpret attrs50227) (sablono.interpreter/interpret content)]))))))) class__4607__auto__ (rum.core/build-class (clojure.core/concat [render-mixin__4606__auto__] [rum/static]) "button") ctor__4608__auto__ (clojure.core/fn [& args__4609__auto__] (clojure.core/let [state__4610__auto__ (rum.core/args->state args__4609__auto__)] (rum.core/element class__4607__auto__ state__4610__auto__ nil)))] (clojure.core/with-meta ctor__4608__auto__ {:rum/class class__4607__auto__})))
```

```clojure
(macroexpand-1
 '(rum/defc button < rum/static
    [& [attrs content]]
    [:button.mdl-button.mdl-js-button ^:attrs attrs content])) ; ^:attrs hint
(def button "" (clojure.core/let [render-mixin__4606__auto__ (rum.core/render->mixin (clojure.core/fn ([& [attrs content]] (do (clojure.core/let [attrs50223 attrs] (clojure.core/apply js/React.createElement "button" (sablono.interpreter/attributes (sablono.normalize/merge-with-class {:class ["mdl-button" "mdl-js-button"]} attrs50223)) [(sablono.interpreter/interpret content)])))))) class__4607__auto__ (rum.core/build-class (clojure.core/concat [render-mixin__4606__auto__] [rum/static]) "button") ctor__4608__auto__ (clojure.core/fn [& args__4609__auto__] (clojure.core/let [state__4610__auto__ (rum.core/args->state args__4609__auto__)] (rum.core/element class__4607__auto__ state__4610__auto__ nil)))] (clojure.core/with-meta ctor__4608__auto__ {:rum/class class__4607__auto__})))
```