### PR TITLE
Do not use wrap-form-element for uncontrolled inputs

### DIFF
--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -68,15 +68,10 @@
        (flatten)
        (str/join " ")))
 
-(defn wrapped-type?
-  "Return true if the element `type` needs to be wrapped."
-  [type]
-  (contains? #{:input :option :textarea} (keyword type)))
-
 (defn react-fn
   "Return the symbol of a fn that build a React element. "
   [type]
-  (if (wrapped-type? type)
+  (if (contains? #{:input :select :textarea} (keyword type))
     'sablono.interpreter/create-element
     'js/React.createElement))
 


### PR DESCRIPTION
When using uncontrolled inputs (`defaultValue` instead of `value`, `defaultChecked` instead of `checked`), `wrap-form-element` will eventually convert it to controlled one by setting `value` on it. React will issue a warning about switching between controlled and uncontrolled flavours which is considered not really supported.

This patch checks if generated input is controlled or not, and switches to wrapped form only for controlled elements.

It also

- saves one closure allocation (`(partial js/React.createElement (name type))`)
- fixes `displayName`
- replaces `createFactory` and `React.DOM` (both considered legacy) with `React.createElement`