### PR TITLE
Don’t join nil classes into classes string

### DIFF
--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -66,6 +66,7 @@
                :else (seq %))
             classes)
        (flatten)
+       (remove nil?)
        (str/join " ")))
 
 (defn react-fn


### PR DESCRIPTION
It started with @fotoetienne noticing in https://github.com/tonsky/rum/issues/99 that

```
[:.c1 { :class nil }]
```

and

```
[:.c1 { :class (when false "...") }]
```

yield different results. This is unfortunate, because in Rum’s server-side rendering, I do not use precompilation step and render HTML based on its value only.

In Sablono, on the other hand, end result might depend on the compilation mode selected:

```
(macroexpand '(html [:.c1 { :class nil }]))
;; => (js/React.createElement "div" #js {:className "c1"})
;; => <div class="c1"></div>

(macroexpand '(html [:.c1 { :class (when false "...") }]))
;; => (js/React.createElement "div" #js {:className (sablono.util/join-classes ["c1" (when false "...")])})
;; => <div class="c1 "></div>
```
(note the extra space after `c1`).


This patch fixes the issue by patching `sablono.util/join-classes` to ignore nils and bringing it on par with the strategy used in all-literal expansion of `html` macro.

I thing you’ll agree that precompilation strategies should be there for speed optimization only, and should yield totally equal results no matter which mode is used.