### PR TITLE
Speed boost by removing `clj->js` and using transducers where applicable

### DIFF
--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -14,39 +14,36 @@
 (defprotocol IJSValue
   (to-js [x]))
 
-(defn compile-map-attr [name value]
-  {name
-   (if (map? value)
-     (to-js value)
-     `(~'clj->js ~value))})
-
 (defmulti compile-attr (fn [name value] name))
 
-(defmethod compile-attr :class [name value]
-  {:class
-   (cond
-     (or (nil? value)
-         (keyword? value)
-         (string? value))
-     value
-     (and (or (sequential? value)
-              (set? value))
-          (every? string? value))
-     (join-classes value)
-     :else `(sablono.util/join-classes ~value))})
+(defmethod compile-attr :class [_ value]
+  (cond
+    (or (nil? value)
+        (keyword? value)
+        (string? value))
+    value
+    (and (or (sequential? value)
+             (set? value))
+         (every? string? value))
+    (join-classes value)
+    :else `(sablono.util/join-classes ~value)))
 
-(defmethod compile-attr :style [name value]
-  (compile-map-attr name (camel-case-keys value)))
+(defmethod compile-attr :style [_ value]
+  (let [value (camel-case-keys value)]
+    (if (map? value)
+      (to-js value)
+      `(~'clj->js ~value))))
 
-(defmethod compile-attr :default [name value]
-  {name (to-js value)})
+(defmethod compile-attr :default [_ value]
+  (to-js value))
 
 (defn compile-attrs
   "Compile a HTML attribute map."
   [attrs]
   (->> (seq attrs)
-       (map #(apply compile-attr %1))
-       (apply merge)
+       (reduce (fn [attrs [name value]]some
+                 (assoc attrs name (compile-attr name value) ))
+               nil)
        (html-to-dom-attrs)
        (to-js)))
 
@@ -267,8 +264,9 @@
   "Convert a map into a JavaScript object."
   [m]
   (JSValue.
-   (zipmap (keys m)
-           (map to-js (vals m)))))
+   (into {}
+         (map (fn [[k v]] [k (to-js v)]))
+         m)))
 
 (extend-protocol IJSValue
   clojure.lang.Keyword
@@ -282,7 +280,7 @@
     (to-js-map x))
   clojure.lang.PersistentVector
   (to-js [x]
-    (JSValue. (vec (map to-js x))))
+    (JSValue. (mapv to-js x)))
   Object
   (to-js [x]
     x)

--- a/src/sablono/core.cljs
+++ b/src/sablono/core.cljs
@@ -16,8 +16,10 @@
     (if (map? (first args))
       (let [[tag & body] (apply func (rest args))]
         (if (map? (first body))
-          (apply vector tag (merge (first body) (first args)) (rest body))
-          (apply vector tag (first args) body)))
+          (into [tag (merge (first body) (first args))]
+                (rest body))
+          (into [tag (first args)]
+                body)))
       (apply func args))))
 
 (defn- update-arglists [arglists]

--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -90,7 +90,12 @@
 
 #?(:cljs
    (defn attributes [attrs]
-     (let [attrs (clj->js (util/html-to-dom-attrs attrs))
+     ;; TODO: Check performance
+     (let [attrs (reduce (fn [obj [k v]]
+                           (aset obj (name k) v)
+                           obj)
+                         (js-obj)
+                         (util/html-to-dom-attrs attrs))
            class (.-className attrs)
            class (if (array? class) (join " " class) class)]
        (if (blank? class)
@@ -101,7 +106,7 @@
 (defn- interpret-seq
   "Interpret the seq `x` as HTML elements."
   [x]
-  (into [] (map interpret) x))
+  (mapv interpret x))
 
 #?(:cljs
    (defn element

--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -90,20 +90,18 @@
 
 #?(:cljs
    (defn attributes [attrs]
-     (let [attr-obj (js-obj)]
-       (doseq [[k v] (-> attrs
-                         (update :class #(if (coll? %) (join " " %) %))
-                         (util/html-to-dom-attrs))]
-         ;; Don't run `aset` for blank `className`
-         (when (or (not= k :className)
-                   (not (blank? v)))
-           (aset attr-obj (name k) v)))
-       attr-obj)))
+     (let [attrs (clj->js (util/html-to-dom-attrs attrs))
+           class (.-className attrs)
+           class (if (array? class) (join " " class) class)]
+       (if (blank? class)
+         (js-delete attrs "className")
+         (set! (.-className attrs) class))
+       attrs)))
 
 (defn- interpret-seq
   "Interpret the seq `x` as HTML elements."
   [x]
-  (mapv interpret x))
+  (map interpret x))
 
 #?(:cljs
    (defn element

--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -90,18 +90,15 @@
 
 #?(:cljs
    (defn attributes [attrs]
-     ;; TODO: Check performance
-     (let [attrs (reduce (fn [obj [k v]]
-                           (aset obj (name k) v)
-                           obj)
-                         (js-obj)
-                         (util/html-to-dom-attrs attrs))
-           class (.-className attrs)
-           class (if (array? class) (join " " class) class)]
-       (if (blank? class)
-         (js-delete attrs "className")
-         (set! (.-className attrs) class))
-       attrs)))
+     (let [attr-obj (js-obj)]
+       (doseq [[k v] (-> attrs
+                         (update :class #(if (coll? %) (join " " %) %))
+                         (util/html-to-dom-attrs))]
+         ;; Don't run `aset` for blank `className`
+         (when (or (not= k :className)
+                   (not (blank? v)))
+           (aset attr-obj (name k) v)))
+       attr-obj)))
 
 (defn- interpret-seq
   "Interpret the seq `x` as HTML elements."

--- a/src/sablono/normalize.cljc
+++ b/src/sablono/normalize.cljc
@@ -7,12 +7,10 @@
 (defn compact-map
   "Removes all map entries where the value of the entry is empty."
   [m]
-  (reduce
-   (fn [m k]
-     (let [v (get m k)]
-       (if (empty? v)
-         (dissoc m k) m)))
-   m (keys m)))
+  (when m
+    (into {}
+          (remove (fn [[_ v]] (empty? v)))
+          m)))
 
 (defn class-name
   [x]
@@ -74,15 +72,17 @@
   "Like clojure.core/merge but concatenate :class entries."
   [& maps]
   (let [maps (map attributes maps)
-        classes (map :class maps)
-        classes (vec (apply concat classes))]
-    (cond-> (apply merge maps)
-      (not (empty? classes))
-      (assoc :class classes))))
+        classes (mapcat :class maps)]
+    (when (seq maps)
+      (cond-> (reduce into {} maps)
+        (not (empty? classes))
+        (assoc :class (vec classes))))))
 
 (defn strip-css
   "Strip the # and . characters from the beginning of `s`."
-  [s] (if s (str/replace s #"^[.#]" "")))
+  [s]
+  (when s
+    (str/replace s #"^[.#]" "")))
 
 (defn match-tag
   "Match `s` as a CSS tag and return a vector of tag name, CSS id and
@@ -92,13 +92,17 @@
         [tag-name names]
         (cond (empty? matches)
               (throw (ex-info (str "Can't match CSS tag: " s) {:tag s}))
+
               (#{\# \.} (ffirst matches)) ;; shorthand for div
               ["div" matches]
+
               :default
               [(first matches) (rest matches)])]
     [tag-name
-     (first (map strip-css (filter #(= \# (first %1)) names)))
-     (vec (map strip-css (filter #(= \. (first %1)) names)))]))
+     (strip-css (some #(when (= \# (first %1)) %1)  names))
+     (into []
+           (comp (filter #(= \. (first %1))) (map strip-css))
+           names)]))
 
 (defn children
   "Normalize the children of a HTML element."
@@ -106,28 +110,36 @@
   (->> (cond
          (string? x)
          (list x)
+
          (util/element? x)
          (list x)
+
          (and (list? x)
               (symbol? x))
          (list x)
+
          (list? x)
          x
+
          (and (sequential? x)
+              (= (count x) 1)
               (sequential? (first x))
               (not (string? (first x)))
-              (not (util/element? (first x)))
-              (= (count x) 1))
+              (not (util/element? (first x))))
          (children (first x))
+
          (sequential? x)
          x
+
          :else (list x))
        (remove nil?)))
 
 (defn element
   "Ensure an element vector is of the form [tag-name attrs content]."
   [[tag & content]]
-  (when (not (or (keyword? tag) (symbol? tag) (string? tag)))
+  (when-not (or (keyword? tag)
+                (symbol? tag)
+                (string? tag))
     (throw (ex-info (str tag " is not a valid element name.") {:tag tag :content content})))
   (let [[tag id class] (match-tag tag)
         tag-attrs (compact-map {:id id :class class})

--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -14,7 +14,7 @@
 (defn as-str
   "Converts its arguments into a string using to-str."
   [& xs]
-  (apply str (map to-str xs)))
+  (str/join (map to-str xs)))
 
 (defn camel-case
   "Returns camel case version of the key, e.g. :http-equiv becomes :httpEquiv."
@@ -36,12 +36,12 @@
   "Recursively transforms all map keys into camel case."
   [m]
   (if (map? m)
-    (let [ks (keys m)
-          kmap (zipmap ks (map camel-case ks))]
-      (-> (rename-keys m kmap)
-          (cond->
-              (map? (:style m))
-            (update-in [:style] camel-case-keys))))
+    (let [kmap (into {}
+                     (map (fn [k] [k (camel-case k)]))
+                     (keys m))]
+      (cond-> (rename-keys m kmap)
+        (map? (:style m))
+        (update-in [:style] camel-case-keys)))
     m))
 
 (defn element?
@@ -61,12 +61,10 @@
 (defn join-classes
   "Join the `classes` with a whitespace."
   [classes]
-  (->> (map #(cond
-               (string? %) %
-               :else (seq %))
-            classes)
-       (flatten)
-       (remove nil?)
+  (->> classes
+       (into [] (comp
+                 (mapcat (fn [x] (if (string? x) [x] (seq x))))
+                 (remove nil?)))
        (str/join " ")))
 
 (defn react-fn

--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -22,26 +22,27 @@
   (if (or (keyword? k)
           (string? k)
           (symbol? k))
-    (let [[first-word & words] (str/split (name k) #"-")]
+    (let [[first-word & words] (.split (name k) "-")]
       (if (or (empty? words)
               (= "aria" first-word)
               (= "data" first-word))
-        k (-> (map str/capitalize words)
-              (conj first-word)
-              str/join
-              keyword)))
+        k
+        (-> (map str/capitalize words)
+            (conj first-word)
+            str/join
+            keyword)))
     k))
 
 (defn camel-case-keys
   "Recursively transforms all map keys into camel case."
   [m]
   (if (map? m)
-    (let [kmap (into {}
-                     (map (fn [k] [k (camel-case k)]))
-                     (keys m))]
-      (cond-> (rename-keys m kmap)
+    (let [m (into {}
+                  (map (fn [[k v]] [(camel-case k) v]))
+                  m)]
+      (cond-> m
         (map? (:style m))
-        (update-in [:style] camel-case-keys)))
+        (update :style camel-case-keys)))
     m))
 
 (defn element?

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -449,7 +449,7 @@
 
 (deftest test-compile-attr-class
   (are [form expected]
-      (= {:class expected} (compile-attr :class form))
+      (= expected (compile-attr :class form))
     nil nil
     "foo" "foo"
     '("foo" "bar" ) "foo bar"

--- a/test/sablono/interpreter_test.cljs
+++ b/test/sablono/interpreter_test.cljs
@@ -20,11 +20,11 @@
       (= expected (js->clj (i/attributes attrs)))
     {} {}
     {:className ""} {}
-    {:className "aa"} {"className" "aa"}
-    {:className "aa bb"} {"className" "aa bb"}
-    {:className ["aa bb"]} {"className" "aa bb"}
+    {:className "aa"}       {"className" "aa"}
+    {:className "aa bb"}    {"className" "aa bb"}
+    {:className ["aa bb"]}  {"className" "aa bb"}
     {:className '("aa bb")} {"className" "aa bb"}
-    {:id :XY} {"id" "XY"}))
+    {:id :XY}               {"id" "XY"}))
 
 (deftest test-interpret-shorthand-div-forms
   (is (= (interpret [:#test.klass1])


### PR DESCRIPTION
This Pull Request implements various small changes which will in sum improve the performance of `interpret` massively. 

In our application [Pepa](https://github.com/bevuta/pepa) we saw slow rendering times dominated by sablono's usage of `clj->js` in `sablono.interpreter/attributes`. While learning about the internals of sablono I noticed various sub-optimal usages of sequence APIs. 

While the major gain comes from the removal of `clj->js`, the other parts should add up to something to: The transducers avoid many small allocations for LazySeqs, especially noticeable in chained sequence operations.

All tests pass, and our Pepa works fine with these changes. However, I can't rule out that the removal of `clj->js` will cause semantic changes. However, these should only be noticeable in exotic usages of attribute-maps, so I doubt the majority of people should see any change at all (except for better performance of course).

You can test out my changes by using `[de.tarn-vedra/sablono "0.7.6-SNAPSHOT"]`

If you're interested I can also post some before/after comparisons of our rendering process, but these will just be micro-benchmarks where I take a screenshot of Chrome's flame-graph before and after my changes :-)
