### PR TITLE
Add a way to skip compilation if a certain metadata tag is set

### DIFF
--- a/README.org
+++ b/README.org
@@ -48,6 +48,16 @@
     (om/root widget {} {:target (. js/document (getElementById "my-app"))})
    #+END_SRC
 
+   By default, /Ŝablono/ will wrap any forms in the body of hiccup with a call to
+   =sablono.interpreter/interpret=. If your code returns a React element, then you can
+   skip the call to this function by marking the s-expression with the metadata tag =:inline=.
+   For example:
+
+   #+BEGIN_SRC clojure :exports code :results silent
+    [:div {}
+     ^:inline (function-that-returns-react-component)]
+      #+END_SRC
+
 ** HTML Tags
 
    /Ŝablono/ only supports tags and attributes that can be handled by

--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -239,6 +239,7 @@
     (literal? content) content
     (hint? content String) content
     (hint? content Number) content
+    (-> content meta :!) content
     :else (compile-form content)))
 
 ;; TODO: Remove when landed in ClojureScript.

--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -239,7 +239,7 @@
     (literal? content) content
     (hint? content String) content
     (hint? content Number) content
-    (-> content meta :!) content
+    (-> content meta :inline) content
     :else (compile-form content)))
 
 ;; TODO: Remove when landed in ClojureScript.

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -276,7 +276,7 @@
     (let [string "x"]
       (are-html-expanded
        '[:span ^String string] '(js/React.createElement "span" nil string)
-       '[:span {} ^:! string] '(js/React.createElement "span" nil string))))
+       '[:span {} ^:inline string] '(js/React.createElement "span" nil string))))
   (testing "values are evaluated only once"
     (let [times-called (atom 0)
           foo #(swap! times-called inc)]

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -275,7 +275,8 @@
   (testing "type hints"
     (let [string "x"]
       (are-html-expanded
-       '[:span ^String string] '(js/React.createElement "span" nil string))))
+       '[:span ^String string] '(js/React.createElement "span" nil string)
+       '[:span {} ^:! string] '(js/React.createElement "span" nil string))))
   (testing "values are evaluated only once"
     (let [times-called (atom 0)
           foo #(swap! times-called inc)]


### PR DESCRIPTION
Right now the only way to tell Sablono to not compile the body is by type hinting it as a `String` or `Number`. Because this type hint doesn't make sense for all cases, I think it would be nice to have a short, general type hint telling Sablono to just return the form, skipping compilation. In this PR I named that type hint `:!` because it is short and can be thought of as "not compiled." I am totally open to other (preferably short) names though.