### PR TITLE
Force lazy seq in interpret-seq to be realized

### DIFF
--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -105,7 +105,10 @@
 (defn- interpret-seq
   "Interpret the seq `x` as HTML elements."
   [x]
-  (map interpret x))
+  ;; Forces the seq x to be realized to avoid a problem caused by a combination
+  ;; of lazy seq and binding (e.g. implementation of om.core/build-all).
+  ;; https://github.com/r0man/sablono/issues/147
+  (into [] (map interpret) x))
 
 #?(:cljs
    (defn element


### PR DESCRIPTION
This PR fixes #147.

Writing simple test about the problem in #147 is difficult because it depends on om implementation.
So I added comment describing the reason for the realization.