### PR TITLE
Add test for map key local variable resolution.

### DIFF
--- a/test/sablono/core_test.cljs
+++ b/test/sablono/core_test.cljs
@@ -1308,3 +1308,10 @@
             :attributes
             {:style "margin-left:2rem;color:red;"}
             :content []}))))
+
+(deftest test-issue-160
+  (let [k :data-foo]
+    (is (= (html-data [:div {k "bar"}])
+           {:tag :div
+            :attributes {:data-foo "bar"}
+            :content []}))))


### PR DESCRIPTION
See discussion in #160.

Note: I tried to verify that this test fails at 0.7.7 (638d3e7), but the tests failed to run:

```
$ lein doo node nodejs auto

Building ...
... done. Elapsed 15.323061661 seconds

;; ======================================================================
;; Testing with Node:

module.js:472
    throw err;
    ^

Error: Cannot find module 'react'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at /Users/kevin/software/sablono/target/nodejs/out/react-dom.inc.js:16:24
    at Object.<anonymous> (/Users/kevin/software/sablono/target/nodejs/out/react-dom.inc.js:40:3)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
```