### PR TITLE
Allow passing values that are not strings as :value for inputs

### DIFF
--- a/src/sablono/interpreter.cljc
+++ b/src/sablono/interpreter.cljc
@@ -43,7 +43,7 @@
               (object/getValueByKeys event "target" property))))
 
          (componentWillReceiveProps [this new-props]
-           (let [state-value (object/getValueByKeys this "state" property)
+           (let [state-value (str (object/getValueByKeys this "state" property))
                  element-value (object/get (js/ReactDOM.findDOMNode this) property)]
              ;; On IE, onChange event might come after actual value of
              ;; an element have changed. We detect this and render


### PR DESCRIPTION
When you create an `:input` element with a `:value` that is not a string (in my case, a number), the element will skip one in every two `:value` updates, because of what happens in this code:

```
;; interpreter.clc:L60
;; suppose state-value is 14, and element-value is "14"
;; first branch gets executed, but it's the second branch we want here (the one which updates the input with a new `:value` from the props)
;; as a result, the new prop is ignored
(if (not= state-value element-value)
  (update-state this new-props property element-value)
  (update-state this new-props property (object/get new-props property)))
```

Adding `str` fixes the problem.