### PR TITLE
Flatten sequences returned by join-classes

### DIFF
--- a/src/sablono/util.cljc
+++ b/src/sablono/util.cljc
@@ -65,6 +65,7 @@
   (->> classes
        (into [] (comp
                  (mapcat (fn [x] (if (string? x) [x] (seq x))))
+                 (flatten)
                  (remove nil?)))
        (str/join " ")))
 


### PR DESCRIPTION
Resolve issue #203 by reintroducing flatten into the composition used by join-classes