### PR TITLE
Support for CSS Custom Properties in the :style property

### DIFF
--- a/src/sablono/compiler.clj
+++ b/src/sablono/compiler.clj
@@ -54,7 +54,7 @@
     :else `(sablono.util/join-classes ~value)))
 
 (defmethod compile-attr :style [_ value]
-  (let [value (camel-case-keys value)]
+  (let [value (style-attribute-camel-case-keys value)]
     (if (map? value)
       (to-js value)
       `(sablono.interpreter/attributes ~value))))

--- a/src/sablono/html.cljc
+++ b/src/sablono/html.cljc
@@ -1,7 +1,8 @@
 (ns sablono.html
   (:refer-clojure :exclude [map meta time])
   (:require [clojure.string :as str]
-            [sablono.protocol :as p])
+            [sablono.protocol :as p]
+            [sablono.util :as util])
   #?(:cljs (:import goog.string.StringBuffer)))
 
 (def MOD 65521)
@@ -468,8 +469,9 @@
                    (pos? v))
               (str "px")))]
     (run! (fn [[k v]]
-            (let [k (name k)]
-              (append! sb (camel->kebab-case k) ":" (coerce-value k v) ";")))
+            (let [k (name k)
+                  k-ident (if (util/css-custom-property? k) k (camel->kebab-case k))]
+              (append! sb k-ident ":" (coerce-value k v) ";")))
           styles)))
 
 (defn render-styles! [sb styles]

--- a/test/sablono/compiler_test.clj
+++ b/test/sablono/compiler_test.clj
@@ -55,6 +55,8 @@
      :style {:background-color '(identity "black")}}
     #j {:className (sablono.util/join-classes (identity "my-class"))
         :style #j {:backgroundColor (identity "black")}}
+    {:style {:--var 1}}
+    #j {:style #j {:--var 1}}
     {:id :XY}
     #j {:id "XY"}))
 
@@ -74,7 +76,9 @@
     {:class '(identity "my-class")
      :style {:background-color '(identity "black")}}
     #j {:className (sablono.util/join-classes '(identity "my-class"))
-        :style #j {:backgroundColor '(identity "black")}}))
+        :style #j {:backgroundColor '(identity "black")}}
+    {:style {:--var 1}}
+    #j {:style #j {:--var 1}}))
 
 (deftest test-to-js
   (let [v (to-js [])]

--- a/test/sablono/util_test.cljc
+++ b/test/sablono/util_test.cljc
@@ -28,6 +28,8 @@
     {:httpEquiv "Expires"}
     {:style {:z-index 1000}}
     {:style {:zIndex 1000}}
+    {:style {:--var 1}}
+    {:style {:--var 1}}
     {:on-click '(fn [e] (let [m {:a-b "c"}]))}
     {:onClick '(fn [e] (let [m {:a-b "c"}]))}
     {'(identity :class) "my-class"
@@ -46,6 +48,8 @@
     {:httpEquiv "Expires"}
     {:style {:z-index 1000}}
     {:style {:zIndex 1000}}
+    {:style {:--var 1}}
+    {:style {:--var 1}}
     {:on-click '(fn [e] (let [m {:a-b "c"}]))}
     {:onClick '(fn [e] (let [m {:a-b "c"}]))}
     {'(identity :class) "my-class"


### PR DESCRIPTION
React supports CSS Custom Properties in the `style` attribute
https://github.com/facebook/react/issues/6411

CSS custom properties are represented by names starting with '--'
https://developer.mozilla.org/en-US/docs/Web/CSS/--*

The code in the PR modifies the camel case transformation so that CSS custom property names are not transformed.